### PR TITLE
Use path-browserify for web environments.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -205,6 +205,14 @@
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true
     },
+    "async": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "requires": {
+        "lodash": "^4.17.14"
+      }
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -502,6 +510,11 @@
         "domelementtype": "1"
       }
     },
+    "duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg=="
+    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -565,6 +578,20 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
+    },
+    "event-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
+      "integrity": "sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==",
+      "requires": {
+        "duplexer": "^0.1.1",
+        "from": "^0.1.7",
+        "map-stream": "0.0.7",
+        "pause-stream": "^0.0.11",
+        "split": "^1.0.1",
+        "stream-combiner": "^0.2.2",
+        "through": "^2.3.8"
+      }
     },
     "execa": {
       "version": "1.0.0",
@@ -670,6 +697,11 @@
         "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
       }
+    },
+    "from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
     },
     "fs-extra": {
       "version": "3.0.1",
@@ -1254,8 +1286,12 @@
     "lodash": {
       "version": "4.17.19",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
-      "dev": true
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+    },
+    "lodash.assign": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
@@ -1328,6 +1364,11 @@
         "p-defer": "^1.0.0"
       }
     },
+    "map-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
+      "integrity": "sha1-ih8HiW2CsQkmvTdEokIACfiJdKg="
+    },
     "markdown-it": {
       "version": "8.4.2",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.2.tgz",
@@ -1399,6 +1440,11 @@
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true
+    },
+    "mingo": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/mingo/-/mingo-1.3.3.tgz",
+      "integrity": "sha1-aSLE0Ufvx3GgFCWixMj3eER4xUY="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -1603,6 +1649,11 @@
         "json-parse-better-errors": "^1.0.1"
       }
     },
+    "path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
+    },
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -1642,6 +1693,14 @@
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         }
+      }
+    },
+    "pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+      "requires": {
+        "through": "~2.3"
       }
     },
     "performance-now": {
@@ -1879,6 +1938,17 @@
         "xtend": "^4.0.1"
       }
     },
+    "save": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/save/-/save-2.4.0.tgz",
+      "integrity": "sha512-wd5L2uVnsKYkIUaK6i8Ie66IOHaI328gMF0MPuTJtYOjXgUolC33LSIk7Qr8WVA55QHaGwfiVS8a7EFIeGOR3w==",
+      "requires": {
+        "async": "^2.6.2",
+        "event-stream": "^4.0.1",
+        "lodash.assign": "^4.2.0",
+        "mingo": "1"
+      }
+    },
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
@@ -1969,6 +2039,14 @@
       "integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA==",
       "dev": true
     },
+    "split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "requires": {
+        "through": "2"
+      }
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -2000,6 +2078,15 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
+      }
+    },
+    "stream-combiner": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+      "integrity": "sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=",
+      "requires": {
+        "duplexer": "~0.1.1",
+        "through": "~2.3.4"
       }
     },
     "string-width": {
@@ -2071,6 +2158,11 @@
         "read-pkg-up": "^4.0.0",
         "require-main-filename": "^2.0.0"
       }
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "to-fast-properties": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,8 @@
     "deep-eql": "^4.0.0",
     "fs-extra": "^3.0.1",
     "get-uri": "^2.0.3",
+    "path-browserify": "1.0.1",
+    "save": "^2.4.0",
     "urijs": "^1.19.1",
     "validator": "^9.4.1",
     "xml2js": "^0.4.19",

--- a/src/jsonschema/jsonSchemaFile.js
+++ b/src/jsonschema/jsonSchemaFile.js
@@ -2,7 +2,7 @@
 
 const debug = require('debug')('xsd2jsonschema:JsonSchemaFile');
 
-const path = require('path');
+const path = typeof process === 'object' ? require('path') : require('path-browserify'),;
 const URI = require('urijs');
 const clone = require('clone');
 const deepEql = require('deep-eql');

--- a/src/jsonschema/jsonSchemaFileDraft04.js
+++ b/src/jsonschema/jsonSchemaFileDraft04.js
@@ -2,7 +2,7 @@
 
 const debug = require('debug')('xsd2jsonschema:JsonSchemaFileDraft04');
 
-const path = require('path');
+const path = typeof process === 'object' ? require('path') : require('path-browserify'),;
 const URI = require('urijs');
 const JsonSchemaFile = require('./jsonSchemaFile');
 const JsonSchemaSerializerDraft04 = require('./jsonSchemaSerializerDraft04');

--- a/src/jsonschema/jsonSchemaFileDraft06.js
+++ b/src/jsonschema/jsonSchemaFileDraft06.js
@@ -2,7 +2,7 @@
 
 const debug = require('debug')('xsd2jsonschema:JsonSchemaFileDraft06');
 
-const path = require('path');
+const path = typeof process === 'object' ? require('path') : require('path-browserify'),;
 const URI = require('urijs');
 const JsonSchemaFileDraft04 = require('./jsonSchemaFileDraft04');
 const JsonSchemaSerializerDraft06 = require('./jsonSchemaSerializerDraft06');

--- a/src/jsonschema/jsonSchemaFileDraft07.js
+++ b/src/jsonschema/jsonSchemaFileDraft07.js
@@ -2,7 +2,7 @@
 
 const debug = require('debug')('xsd2jsonschema:JsonSchemaFileDraft07');
 
-const path = require('path');
+const path = typeof process === 'object' ? require('path') : require('path-browserify'),;
 const URI = require('urijs');
 const JsonSchemaFileDraft06 = require('./jsonSchemaFileDraft06');
 


### PR DESCRIPTION
This PR adds support for using `path-browserify` for environments where native `path` is not present (i.e. on web environments)