### PR TITLE
Update jsonSchemaRef.js

### DIFF
--- a/src/jsonschema/jsonSchemaRef.js
+++ b/src/jsonschema/jsonSchemaRef.js
@@ -82,7 +82,7 @@ class JsonSchemaRef extends JsonSchemaFile {
             ref.resolveRef(type);
         })
         if (type.ref == undefined) {
-            this.$ref = type.$ref.toString();
+            this.$ref = "";
         } else {
             this.$ref = type.ref.toString();
         }


### PR DESCRIPTION
Causes error when trying to call function .toString on "undefined". This was interrupting conversions on my end. Changing this line fixed the issue -- however I am not sure if setting $ref to "" is the correct solution or will cause other issues.